### PR TITLE
Increased SHM size by mounting a volume

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -116,6 +116,15 @@ controller:
       podAnnotations: {}
       nodeSelector: {}
 
+  extraVolumeMounts: 
+    - name: shared-memory
+      mountPath: /dev/shm
+
+  extraVolumes:
+    - name: shared-memory
+      emptyDir: 
+        medium: Memory
+
 defaultBackend:
   enabled: true
 


### PR DESCRIPTION
This PR increases shared memory for Nginx ingress controller in order to fix an issue we're currently having in live-1: 

```console
"modsecurity_rules" directive Failed to allocate shared memory (1): No space left on device in /tmp/nginx-cfg337881831:12572
```

The problem is Kubernetes only provides 64MB for shared memory [1] which doesn't look enough for our nginx-ingress-controllers (they're getting bigger every day). Some other applications ([like PostgreSQL](https://github.com/timescale/timescaledb-kubernetes/blob/master/charts/timescaledb-single/values.yaml#L302)) are also implementing similar approaches.

---

[1] Easly checked as:
```console
bash-5.0$ df -h | grep shm
shm                      64.0M         0     64.0M   0% /dev/shm
bash-5.0$
```