### PR TITLE
Deleted dependence_deploy variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ module "ingress_controllers" {
 
   # This module requires helm and OPA already deployed
   dependence_prometheus  = helm_release.prometheus_operator
-  dependence_deploy      = null_resource.deploy
   dependence_opa         = module.opa.helm_opa_status
   dependence_certmanager = helm_release.cert-manager
 }
@@ -24,7 +23,6 @@ module "ingress_controllers" {
 | Name                            | Description                                                   | Type | Default | Required |
 |---------------------------------|---------------------------------------------------------------|:----:|:-------:|:--------:|
 | dependence_prometheus  | Prometheus Dependence variable                                         | string   |       | yes |
-| dependence_deploy      | Deploy (helm) dependence variable                                      | string   |       | yes |
 | dependence_opa         | Priority class dependence                                              | string   |       | yes |
 | dependence_certmanager | This module deploys lets-encrypt certs, so it depends on certmanager   | string   |       | yes |
 | cluster_domain_name    | Value used for externalDNS annotations and certmanager                 | string   |       | yes |

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,6 @@ resource "helm_release" "nginx_ingress" {
   // self-signed certificate until the proper one becomes available. This
   // dependency is not captured here.
   depends_on = [
-    var.dependence_deploy,
     var.dependence_prometheus,
     var.dependence_opa,
   ]

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,3 @@
-
-variable "dependence_deploy" {
-  description = "Deploy Module dependence in order to be executed (deploy resource is the helm init)"
-}
-
 variable "dependence_opa" {
   description = "OPA module dependences in order to be executed."
 }


### PR DESCRIPTION
This variable was needed when we were using Helm 2, it was the way to tell Helm Chart inside our terraform modules to wait for tiller before getting installed.

Now we are using Helm 3 and there is not tiller in the clusters.