### PR TITLE
Disable ModSecurity in the default Ingress controller

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -4,7 +4,7 @@ controller:
   electionID: ingress-controller-leader-acme
 
   config:
-    enable-modsecurity: "true"
+    enable-modsecurity: "false"
     custom-http-errors: 413,502,503,504
     generate-request-id: "true"
     proxy-buffer-size: "16k"


### PR DESCRIPTION
This change will disable ModSecurity in the default ingress-controller - "nginx"