### PR TITLE
Add cert-manager dependency for nginx_ingress

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,7 @@ resource "helm_release" "nginx_ingress" {
   depends_on = [
     var.dependence_prometheus,
     var.dependence_opa,
+    var.dependence_certmanager
   ]
 
   lifecycle {


### PR DESCRIPTION
Destroy cluster fails some times as ingress-controller namespace stuck in terminating state.
"reason":"ContentDeletionFailed","message":"Failed to delete all resource types, 1 remaining: conversion webhook for acme.cert-manager.io/v1alpha2

Added dependency to "helm_release" "nginx_ingress" to fix this issue