### PR TITLE
Suppress "Server" header in http responses

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -5,6 +5,7 @@ controller:
 
   config:
     enable-modsecurity: "false"
+    server-tokens: "false"
     custom-http-errors: 413,502,503,504
     generate-request-id: "true"
     proxy-buffer-size: "16k"


### PR DESCRIPTION
We have had at least 2 requests from service teams to prevent the nginx version being visible in HTTP responses from their services.

AFAICT, this can only be done at the ingress-controller level - not at the ingress level.

This change should suppress the "Server" header altogether, so that no information about which webserver we use, and what version, is sent back in response to HTTP requests.

fixes https://github.com/ministryofjustice/cloud-platform/issues/1054 (for ingresses on the default controller)