### PR TITLE
Remove destroy-time provisioners

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -94,17 +94,6 @@ EOS
 
   }
 
-  provisioner "local-exec" {
-    when = destroy
-
-    command = <<EOS
-kubectl delete -n ingress-controllers -f - <<EOF
-${data.template_file.nginx_ingress_default_certificate.rendered}
-EOF
-EOS
-
-  }
-
   triggers = {
     contents = sha1(
       data.template_file.nginx_ingress_default_certificate.rendered,


### PR DESCRIPTION
These are no longer supported by Terraform 0.13.0 and up.
https://www.terraform.io/upgrade-guides/0-13.html#destroy-time-provisioners-may-not-refer-to-other-resources