### PR TITLE
Update default certificate of "live" cluster

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,7 @@ data "template_file" "nginx_ingress_default_certificate" {
   vars = {
     common_name = "*.apps.${var.cluster_domain_name}"
     alt_name    = var.is_live_cluster ? format("- '*.%s'", var.live_domain) : ""
+    live1_dns   = var.live1_cert_dns_name
   }
 }
 

--- a/templates/default-certificate.yaml.tpl
+++ b/templates/default-certificate.yaml.tpl
@@ -11,3 +11,4 @@ spec:
   dnsNames:
     - '${common_name}'
     ${alt_name}
+    ${live1_dns}

--- a/variables.tf
+++ b/variables.tf
@@ -24,4 +24,7 @@ variable "live_domain" {
 variable "cluster_domain_name" {
   description = "The cluster domain used for externalDNS annotations and certmanager"
 }
-
+variable "live1_cert_dns_name" {
+  description = "This is to add the live-1 dns name for eks-live cluster default certificate"
+  default = ""
+}


### PR DESCRIPTION
This is to include *.apps.live-1, so users can use apps.live-1 domain, when migrating to eks-live cluster.

This is related to the issue:
https://github.com/ministryofjustice/cloud-platform/issues/3013