### PR TITLE
Create default certificate using kubectl_manifest replaing null_resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,9 +72,10 @@ data "template_file" "nginx_ingress_default_certificate" {
   )
 
   vars = {
-    common_name = "*.apps.${var.cluster_domain_name}"
-    alt_name    = var.is_live_cluster ? format("- '*.%s'", var.live_domain) : ""
-    live1_dns   = var.live1_cert_dns_name
+    common_name  = "*.apps.${var.cluster_domain_name}"
+    cluster_name = "*.${var.cluster_domain_name}"
+    alt_name     = var.is_live_cluster ? format("- '*.%s'", var.live_domain) : ""
+    live1_dns    = var.live1_cert_dns_name
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -65,38 +65,20 @@ resource "helm_release" "nginx_ingress" {
 
 
 # Default Lets-Encrypt cert 
-
-data "template_file" "nginx_ingress_default_certificate" {
-  template = file(
-    "${path.module}/templates/default-certificate.yaml.tpl",
-  )
-
+data "kubectl_path_documents" "nginx_ingress_default_certificate" {
+    pattern = "${path.module}/templates/default-certificate.yaml.tpl"
   vars = {
-    common_name  = "*.apps.${var.cluster_domain_name}"
-    cluster_name = "*.${var.cluster_domain_name}"
-    alt_name     = var.is_live_cluster ? format("- '*.%s'", var.live_domain) : ""
-    live1_dns    = var.live1_cert_dns_name
+    apps_cluster_name = "*.apps.${var.cluster_domain_name}"
+    cluster_name      = "*.${var.cluster_domain_name}"
+    alt_name          = var.is_live_cluster ? format("- '*.%s'", var.live_domain) : ""
+    apps_alt_name     = var.is_live_cluster ? format("- '*.apps.%s'", var.live_domain) : ""
+    live1_dns         = var.live1_cert_dns_name
   }
 }
 
-resource "null_resource" "nginx_ingress_default_certificate" {
+resource "kubectl_manifest" "nginx_ingress_default_certificate" {
+  count     = length(data.kubectl_path_documents.nginx_ingress_default_certificate.documents)
+  yaml_body = element(data.kubectl_path_documents.nginx_ingress_default_certificate.documents, count.index)
+
   depends_on = [var.dependence_certmanager]
-
-  provisioner "local-exec" {
-    command = <<EOS
-kubectl apply -n ingress-controllers -f - <<EOF
-${data.template_file.nginx_ingress_default_certificate.rendered}
-EOF
-EOS
-
-  }
-
-  provisioner "local-exec" {
-    when    = destroy
-    command = "kubectl -n ingress-controllers delete certificate default"
-  }
-
-  triggers = {
-    contents = sha1(data.template_file.nginx_ingress_default_certificate.rendered)
-  }
 }

--- a/templates/default-certificate.yaml.tpl
+++ b/templates/default-certificate.yaml.tpl
@@ -9,7 +9,8 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - '${common_name}'
+    - '${apps_cluster_name}'
     - '${cluster_name}'
     ${alt_name}
+    ${apps_alt_name}
     ${live1_dns}

--- a/templates/default-certificate.yaml.tpl
+++ b/templates/default-certificate.yaml.tpl
@@ -10,5 +10,6 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - '${common_name}'
+    - '${cluster_name}'
     ${alt_name}
     ${live1_dns}

--- a/versions.tf
+++ b/versions.tf
@@ -12,6 +12,10 @@ terraform {
     template = {
       source = "hashicorp/template"
     }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.7.0"
+    }
   }
   required_version = ">= 0.13"
 }


### PR DESCRIPTION
   - As we are seeing multiple issues using null_resource, replacing this with  kubectl_manifest.
   - Add '*.apps.<cluster_domain_name>' to all clusters
   - Add '*.apps.cloud-platform.service.justice.gov.uk' to live_clusters