### PR TITLE
Custom error page image bump, wildcard to external-dns annotation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@
 ##########
 
 locals {
-  external_dns_annotation = "*.apps.${var.cluster_domain_name},apps.${var.cluster_domain_name}${var.is_live_cluster ? format(",*.%s", var.live_domain) : ""}"
+  external_dns_annotation = "*.apps.${var.cluster_domain_name},*.${var.cluster_domain_name}${var.is_live_cluster ? format(",*.%s", var.live_domain) : ""}"
 }
 
 #############

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -147,7 +147,7 @@ defaultBackend:
   name: default-backend
   image:
     repository: ministryofjustice/cloud-platform-custom-error-pages
-    tag: "0.5"
+    tag: "0.6"
 
 rbac:
   create: true


### PR DESCRIPTION
- Bump custom error page image to 0.6. Closes: https://github.com/ministryofjustice/cloud-platform/issues/3192
Add wildcard to domain apps.<cluster-domain> to handle record set of all sub domains