### PR TITLE
Use ingressClass from controller name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ No Modules.
 | cluster\_domain\_name | The cluster domain used for externalDNS annotations and certmanager | `any` | n/a | yes |
 | controller\_name | Will be used as the ingress controller name and the class annotation | `string` | n/a | yes |
 | default\_cert | Useful if you want to use a default certificate for your ingress controller. Format: namespace/secretName | `string` | `"ingress-controllers/default-certificate"` | no |
+| enable\_latest\_tls | Provide support to tlsv1.3 along with tlsv1.2 | `bool` | `false` | no |
 | enable\_modsec | Enable https://github.com/SpiderLabs/ModSecurity-nginx | `bool` | `false` | no |
 | enable\_owasp | Use default ruleset from https://github.com/SpiderLabs/owasp-modsecurity-crs/ | `bool` | `false` | no |
 | is\_live\_cluster | For live clusters externalDNS annotation will have var.live\_domain (default *.cloud-platform.service.justice.gov.uk) | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,7 @@ resource "helm_release" "nginx_ingress" {
     controller_name         = var.controller_name
     controller_value        = var.controller_name == "nginx" ? "k8s.io/ingress-nginx" : "k8s.io/ingress-${var.controller_name}"
     enable_modsec           = var.enable_modsec
+    enable_latest_tls       = var.enable_latest_tls
     enable_owasp            = var.enable_owasp
     default                 = var.controller_name == "nginx" ? true : false
     name_override           = var.controller_name == "nginx" ? "ingress-nginx" : "ingress-${var.controller_name}"

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -22,6 +22,7 @@ controller:
       maxUnavailable: 1
     type: RollingUpdate
 
+  ingressClass: ${controller_name}
   minReadySeconds: 12
   watchIngressWithoutClass: ${default}
   ingressClassByName: ${default}

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -22,14 +22,27 @@ controller:
       maxUnavailable: 1
     type: RollingUpdate
 
-  ingressClass: ${controller_name}
   minReadySeconds: 12
+
+  # -- Process Ingress objects without ingressClass annotation/ingressClassName field
+  # Overrides value for --watch-ingress-without-class flag of the controller binary
+  # Defaults to false
   watchIngressWithoutClass: ${default}
+  # -- Process IngressClass per name (additionally as per spec.controller).
   ingressClassByName: ${default}
+
+  ## This section refers to the creation of the IngressClass resource
   ingressClassResource:
+    # -- Name of the ingressClass
     name: ${controller_name}
+    # -- Is this the default ingressClass for the cluster
     default: ${default}
+    # -- Controller-value of the controller that is processing this ingressClass
     controllerValue: ${controller_value}
+
+  # -- For backwards compatibility with ingress.class annotation, use ingressClass.
+  # Algorithm is as follows, first ingressClassName is considered, if not present, controller looks for ingress.class annotation
+  ingressClass: ${controller_name}
 
   electionID: ingress-controller-leader-${controller_name}
 
@@ -51,10 +64,15 @@ controller:
     generate-request-id: "true"
     proxy-buffer-size: "16k"
     proxy-body-size: "50m"
+
+%{ if enable_latest_tls }
+    ssl-protocols: "TLSv1.2 TLSv1.3"
+%{ else ~}  
     # Config below is for old TLS versions. Specifically an incident with IE11 on
     # bank-admin.prisoner-money.service.justice.gov.uk. More info CP Incidents page.
     ssl-ciphers: "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA"
     ssl-protocols: "TLSv1 TLSv1.1 TLSv1.2"
+%{ endif ~}
     server-snippet: |
       if ($scheme != 'https') {
         return 308 https://$host$request_uri;

--- a/variables.tf
+++ b/variables.tf
@@ -45,3 +45,9 @@ variable "enable_owasp" {
   type        = bool
   default     = false
 }
+
+variable "enable_latest_tls" {
+  description = "Provide support to tlsv1.3 along with tlsv1.2"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
As it is by default named as Nginx

More info:
```
  # -- For backwards compatibility with ingress.class annotation, use ingressClass.
  # Algorithm is as follows, first ingressClassName is considered, if not present, controller looks for ingress.class annotation
  ingressClass: nginx
```

Add a condition to support tlsv1.3 along with tlsv1.2, this can be used for new ingress controllers