### PR TITLE
Condition to enable external-dns annoation for svc

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ No Modules.
 | cluster\_domain\_name | The cluster domain used for externalDNS annotations and certmanager | `any` | n/a | yes |
 | controller\_name | Will be used as the ingress controller name and the class annotation | `string` | n/a | yes |
 | default\_cert | Useful if you want to use a default certificate for your ingress controller. Format: namespace/secretName | `string` | `"ingress-controllers/default-certificate"` | no |
+| enable\_external\_dns\_annotation | Add external dns annotation for service | `bool` | `false` | no |
 | enable\_latest\_tls | Provide support to tlsv1.3 along with tlsv1.2 | `bool` | `false` | no |
 | enable\_modsec | Enable https://github.com/SpiderLabs/ModSecurity-nginx | `bool` | `false` | no |
 | enable\_owasp | Use default ruleset from https://github.com/SpiderLabs/owasp-modsecurity-crs/ | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -45,17 +45,18 @@ resource "helm_release" "nginx_ingress" {
   version    = "4.0.17"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
-    metrics_namespace       = "ingress-controllers"
-    external_dns_annotation = local.external_dns_annotation
-    replica_count           = var.replica_count
-    default_cert            = var.default_cert
-    controller_name         = var.controller_name
-    controller_value        = var.controller_name == "nginx" ? "k8s.io/ingress-nginx" : "k8s.io/ingress-${var.controller_name}"
-    enable_modsec           = var.enable_modsec
-    enable_latest_tls       = var.enable_latest_tls
-    enable_owasp            = var.enable_owasp
-    default                 = var.controller_name == "nginx" ? true : false
-    name_override           = var.controller_name == "nginx" ? "ingress-nginx" : "ingress-${var.controller_name}"
+    metrics_namespace               = "ingress-controllers"
+    external_dns_annotation         = local.external_dns_annotation
+    replica_count                   = var.replica_count
+    default_cert                    = var.default_cert
+    controller_name                 = var.controller_name
+    controller_value                = var.controller_name == "nginx" ? "k8s.io/ingress-nginx" : "k8s.io/ingress-${var.controller_name}"
+    enable_modsec                   = var.enable_modsec
+    enable_latest_tls               = var.enable_latest_tls
+    enable_owasp                    = var.enable_owasp
+    default                         = var.controller_name == "nginx" ? true : false
+    name_override                   = var.controller_name == "nginx" ? "ingress-nginx" : "ingress-${var.controller_name}"
+    enable_external_dns_annotation  = var.enable_external_dns_annotation
   })]
 
   depends_on = [

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -142,7 +142,9 @@ controller:
 
   service:
     annotations:
+%{ if enable_external_dns_annotation }
       external-dns.alpha.kubernetes.io/hostname: "${external_dns_annotation}"
+%{~ endif ~}
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
       service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     externalTrafficPolicy: "Local"

--- a/variables.tf
+++ b/variables.tf
@@ -51,3 +51,9 @@ variable "enable_latest_tls" {
   type        = bool
   default     = false
 }
+
+variable "enable_external_dns_annotation" {
+  description = "Add external dns annotation for service"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This will fix the upsert issue in external-dns, by making sure multiple ingress controllers don't have the same annotation.