### PR TITLE
release 1.2.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ resource "helm_release" "nginx_ingress" {
   chart      = "ingress-nginx"
   namespace  = "ingress-controllers"
   repository = "https://kubernetes.github.io/ingress-nginx"
-  version    = "4.1.2"
+  version    = "4.1.4"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     metrics_namespace              = "ingress-controllers"


### PR DESCRIPTION
added a security-related toggle: 
 This release removes the root and alias directives in NGINX, this can avoid some potential security attacks.
chart 4.1.4
