### PR TITLE
Refactor to meet standardised Terraform structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,19 @@ See [example](example/) dir
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.6.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >=2.6.0 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >=1.13.2 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >=2.12.1 |
+| <a name="requirement_template"></a> [template](#requirement\_template) | >=2.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.6.0 |
-| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | n/a |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | n/a |
-| <a name="provider_template"></a> [template](#provider\_template) | n/a |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >=2.6.0 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >=1.13.2 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >=2.12.1 |
+| <a name="provider_template"></a> [template](#provider\_template) | >=2.2.0 |
 
 ## Modules
 

--- a/example/ingress.tf
+++ b/example/ingress.tf
@@ -1,11 +1,11 @@
 module "ingress_controllers" {
   source = "../"
 
-  replica_count       = "2"
-  controller_name     = "default"
-  cluster_domain_name = "dummy"
-  is_live_cluster     = false
-  live1_cert_dns_name = "dummy"
+  replica_count          = "2"
+  controller_name        = "default"
+  cluster_domain_name    = "dummy"
+  is_live_cluster        = false
+  live1_cert_dns_name    = "dummy"
   dependence_certmanager = "ignore"
 
 }
@@ -13,13 +13,13 @@ module "ingress_controllers" {
 module "modsec_ingress_controllers" {
   source = "../"
 
-  replica_count       = "2"
-  controller_name     = "modsec"
-  cluster_domain_name = "dummy"
-  is_live_cluster     = false
-  live1_cert_dns_name = "dummy"
-  enable_modsec       = true
-  enable_owasp        = true
+  replica_count          = "2"
+  controller_name        = "modsec"
+  cluster_domain_name    = "dummy"
+  is_live_cluster        = false
+  live1_cert_dns_name    = "dummy"
+  enable_modsec          = true
+  enable_owasp           = true
   dependence_certmanager = "ignore"
 
   depends_on = [module.ingress_controllers]

--- a/main.tf
+++ b/main.tf
@@ -118,6 +118,6 @@ resource "kubernetes_config_map" "modsecurity_nginx_config" {
   ]
 
   lifecycle {
-    ignore_changes = [metadata.0.annotations]
+    ignore_changes = [metadata[0].annotations]
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,19 +2,19 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.6.0"
+      version = ">=2.6.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
-    }
-    null = {
-      source = "hashicorp/null"
+      source  = "hashicorp/kubernetes"
+      version = ">=2.12.1"
     }
     template = {
-      source = "hashicorp/template"
+      source  = "hashicorp/template"
+      version = ">=2.2.0"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source  = "gavinbunney/kubectl"
+      version = ">=1.13.2"
     }
   }
   required_version = ">= 0.14"


### PR DESCRIPTION
This PR:

- runs terraform fmt
- updates dot notation to square bracket notation for list items
- adds minimum provider versions
- removes the unused `null` provider