### PR TITLE
Revert audit logs sending to stdout

### DIFF
--- a/templates/modsecurity.conf
+++ b/templates/modsecurity.conf
@@ -234,7 +234,7 @@ SecAuditLogParts AEFHKZ
 # assumes that you will use the audit log only ocassionally.
 #
 SecAuditLogType Serial
-SecAuditLog /dev/stdout
+SecAuditLog /var/log/modsec_audit.log
 SecAuditLogFormat JSON
 SecRuleRemoveById 920350
 


### PR DESCRIPTION
Sending audit logs to stdout is too much logs for fluent-bit and getting `failed to flush chunk`. So need to find an alternative to send audit logs to ES