### PR TITLE
Revert "chore: 🤖 fix malformed json logs"

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -130,9 +130,9 @@ controller:
       "ssl_session_id": "$ssl_session_id",
       "status": $status,
       "upstream_addr": "$upstream_addr",
-      "upstream_response_length": "$upstream_response_length",
-      "upstream_response_time": "$upstream_response_time",
-      "upstream_status": "$upstream_status"
+      "upstream_response_length": $upstream_response_length,
+      "upstream_response_time": $upstream_response_time,
+      "upstream_status": $upstream_status
       }
 
   publishService:


### PR DESCRIPTION
Reverts ministryofjustice/cloud-platform-terraform-ingress-controller#58

Fluent-bit throw error "failed to flush chunk" when pushing these documents/logs to the ES. Further debugging shows these fields cannot be parses as the data type it expects is different e.g invalid input `upstream_status`.

The revert is not because the ingress log format is wrong. The previous format for these fields were stored as different datatype in elasticsearch and when the format type changes, the ES cannot match it to the existing fields.
