### PR TITLE
Send audit logs back to stdout

### DIFF
--- a/templates/modsecurity.conf
+++ b/templates/modsecurity.conf
@@ -234,7 +234,7 @@ SecAuditLogParts AEFHKZ
 # assumes that you will use the audit log only ocassionally.
 #
 SecAuditLogType Serial
-SecAuditLog /var/log/modsec_audit.log
+SecAuditLog /dev/stdout
 SecAuditLogFormat JSON
 SecRuleRemoveById 920350
 


### PR DESCRIPTION
Reverts ministryofjustice/cloud-platform-terraform-ingress-controller#59

The "failed to flush chunk" error which is caused by wrong datatype value when parsing json is fixed in this PR:https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/pull/60
Hence, send audit logs back to stdout to be streamed to new elasticsearch