### PR TITLE
Update Helm release to 4.5.2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ resource "helm_release" "nginx_ingress" {
   chart      = "ingress-nginx"
   namespace  = "ingress-controllers"
   repository = "https://kubernetes.github.io/ingress-nginx"
-  version    = "4.1.4"
+  version    = "4.5.2"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     metrics_namespace              = "ingress-controllers"


### PR DESCRIPTION
This PR brings ingress controller to latest supported version for Kubernetes 1.23.

https://github.com/kubernetes/ingress-nginx#supported-versions-table

```
ingress-nginx v1.2.1 > 1.6.4
nginx v1.19.10 > 1.21.6
helm chart v4.1.4 > 4.5.2
```