### PR TITLE
Increase timeout for tf state of namespace

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,9 @@ resource "kubernetes_namespace" "ingress_controllers" {
       "cloud-platform-out-of-hours-alert"                           = "true"
     }
   }
+  timeouts {
+    delete = "10m"
+  }
 }
 
 ########


### PR DESCRIPTION
cluster components deletion timeout on module.ingress_controllers_v1.kubernetes_namespace.ingress_controllers[0]:
Error: context deadline exceeded

Increase the timeout while the actual resources take time to delete in the cluster