### PR TITLE
Swap volumeMount to set the deployment with both mountPath

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -96,10 +96,11 @@ controller:
           service cron start
           sleep infinity 
       volumeMounts:
-      - name: logs-volume
-        mountPath: /var/log/audit/
       - name: logrotate-config
         mountPath: /home
+      - name: logs-volume
+        mountPath: /var/log/audit/
+
 %{ endif ~}
 
   # -- Process Ingress objects without ingressClass annotation/ingressClassName field


### PR DESCRIPTION
This PR simply swaps the volumeMount to trigger the deployment and set both volumeMount to the logrotate container.

 A high-priority alert triggered for node Memory-Critical. While investigating, the modsec-controller has increased in the memory usage as shown in the grafana graph. 
![Screenshot 2023-12-28 at 14 33 54](https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/assets/51324851/f5d84d73-b89e-40d1-91c2-c00a406018be)
This is because the logrotate didnot perform the audit log cleanup from the controller container and the volumeMount to  `var/log/audit` on the logrotate container is missing in deployment of the modsec-controller.

The reason is, during the terraform apply for removing the duplicate VolumeMounts, the helm_release terraform missed to check that this is duplicate and removed the existing one. But the code still refers to both the volumeMounts.

