### PR TITLE
Configure memory requests and limits as variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ No modules.
 | <a name="input_is_live_cluster"></a> [is\_live\_cluster](#input\_is\_live\_cluster) | For live clusters externalDNS annotation will have var.live\_domain (default *.cloud-platform.service.justice.gov.uk) | `bool` | `false` | no |
 | <a name="input_live1_cert_dns_name"></a> [live1\_cert\_dns\_name](#input\_live1\_cert\_dns\_name) | This is to add the live-1 dns name for eks-live cluster default certificate | `string` | `""` | no |
 | <a name="input_live_domain"></a> [live\_domain](#input\_live\_domain) | The live domain used for externalDNS annotation | `string` | `"cloud-platform.service.justice.gov.uk"` | no |
+| <a name="input_memory_limits"></a> [memory\_limits](#input\_memory\_limits) | value for resources:limits memory value | `string` | `"2Gi"` | no |
+| <a name="input_memory_requests"></a> [memory\_requests](#input\_memory\_requests) | value for resources:requests memory value | `string` | `"512Mi"` | no |
 | <a name="input_opensearch_modsec_audit_host"></a> [opensearch\_modsec\_audit\_host](#input\_opensearch\_modsec\_audit\_host) | domain endpoint for the opensearch cluster | `string` | `""` | no |
 | <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | Number of replicas set in deployment | `string` | n/a | yes |
 

--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,8 @@ resource "helm_release" "nginx_ingress" {
     enable_owasp                   = var.enable_owasp
     default                        = var.controller_name == "default" ? true : false
     name_override                  = "ingress-${var.controller_name}"
+    memory_requests         =  var.memory_requests
+    memory_limits            = var.memory_limits
     enable_external_dns_annotation = var.enable_external_dns_annotation
     backend_repo                   = var.backend_repo
     backend_tag                    = var.backend_tag

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -154,9 +154,9 @@ controller:
 
   resources:
     limits:
-      memory: 12Gi
+      memory: ${memory_limits}
     requests:
-      memory: 512Mi
+      memory: ${memory_requests}
 
   config:
     worker-shutdown-timeout: "440s"

--- a/variables.tf
+++ b/variables.tf
@@ -68,6 +68,18 @@ variable "enable_external_dns_annotation" {
   default     = false
 }
 
+variable "memory_limits" {
+  description = "value for resources:limits memory value"
+  default     = "2Gi"
+  type        = string
+}
+
+variable "memory_requests" {
+  description = "value for resources:requests memory value"
+  default     = "512Mi"
+  type        = string
+}
+
 variable "cluster" {
   description = " cluster name used for opensearch indicies"
   type        = string


### PR DESCRIPTION
Configure resources:limits and resource:requests of memory as variables so it can be changed for different controller i.e. default and modsec. And a different value for test clusters