### PR TITLE
perf: ⚡️ pass in the ability to configure `proxy-buffering`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,13 @@ No modules.
 | <a name="input_enable_owasp"></a> [enable\_owasp](#input\_enable\_owasp) | Use default ruleset from https://github.com/SpiderLabs/owasp-modsecurity-crs/ | `bool` | `false` | no |
 | <a name="input_fluent_bit_version"></a> [fluent\_bit\_version](#input\_fluent\_bit\_version) | fluent bit container version used to exrtact modsec audit logs | `string` | `"2.1.8-amd64"` | no |
 | <a name="input_is_live_cluster"></a> [is\_live\_cluster](#input\_is\_live\_cluster) | For live clusters externalDNS annotation will have var.live\_domain (default *.cloud-platform.service.justice.gov.uk) | `bool` | `false` | no |
-| <a name="input_keepalive"></a> [keepalive](#input\_keepalive) | the maximum number of idle keepalive connections to upstream servers that are preserved in the cache of each worker process. When this number is exceeded, the least recently used connections are closed. https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive | `number` | `0` | no |
+| <a name="input_keepalive"></a> [keepalive](#input\_keepalive) | the maximum number of idle keepalive connections to upstream servers that are preserved in the cache of each worker process. When this number is exceeded, the least recently used connections are closed. https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive | `number` | `320` | no |
 | <a name="input_live1_cert_dns_name"></a> [live1\_cert\_dns\_name](#input\_live1\_cert\_dns\_name) | This is to add the live-1 dns name for eks-live cluster default certificate | `string` | `""` | no |
 | <a name="input_live_domain"></a> [live\_domain](#input\_live\_domain) | The live domain used for externalDNS annotation | `string` | `"cloud-platform.service.justice.gov.uk"` | no |
 | <a name="input_memory_limits"></a> [memory\_limits](#input\_memory\_limits) | value for resources:limits memory value | `string` | `"2Gi"` | no |
 | <a name="input_memory_requests"></a> [memory\_requests](#input\_memory\_requests) | value for resources:requests memory value | `string` | `"512Mi"` | no |
 | <a name="input_opensearch_modsec_audit_host"></a> [opensearch\_modsec\_audit\_host](#input\_opensearch\_modsec\_audit\_host) | domain endpoint for the opensearch cluster | `string` | `""` | no |
+| <a name="input_proxy_response_buffering"></a> [proxy\_response\_buffering](#input\_proxy\_response\_buffering) | nginx receives a response from the proxied server as soon as possible, saving it into the buffers set by the proxy\_buffer\_size and proxy\_buffers directives. If the whole response does not fit into memory, a part of it can be saved to a temporary file on the disk. https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering | `string` | `"off"` | no |
 | <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | Number of replicas set in deployment | `string` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ resource "helm_release" "nginx_ingress" {
     enable_latest_tls              = var.enable_latest_tls
     enable_owasp                   = var.enable_owasp
     keepalive                      = var.keepalive
-    proxy_buffering                = var.proxy_response_buffering
+    proxy_response_buffering       = var.proxy_response_buffering
     default                        = var.controller_name == "default" ? true : false
     name_override                  = "ingress-${var.controller_name}"
     memory_requests                = var.memory_requests

--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,7 @@ resource "helm_release" "nginx_ingress" {
     enable_latest_tls              = var.enable_latest_tls
     enable_owasp                   = var.enable_owasp
     keepalive                      = var.keepalive
+    proxy_buffering                = var.proxy_response_buffering
     default                        = var.controller_name == "default" ? true : false
     name_override                  = "ingress-${var.controller_name}"
     memory_requests                = var.memory_requests

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -168,6 +168,7 @@ controller:
     proxy-buffer-size: "16k"
     proxy-body-size: "50m"
     keepalive: ${keepalive}
+    proxy-buffering: ${proxy_response_buffering}
 
 %{ if enable_latest_tls }
     ssl-protocols: "TLSv1.2 TLSv1.3"

--- a/variables.tf
+++ b/variables.tf
@@ -71,9 +71,14 @@ variable "enable_external_dns_annotation" {
 variable "keepalive" {
   description = "the maximum number of idle keepalive connections to upstream servers that are preserved in the cache of each worker process. When this number is exceeded, the least recently used connections are closed. https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive"
   type        = number
-  default     = 0
+  default     = 320
 }
 
+variable "proxy_response_buffering" {
+  description = "nginx receives a response from the proxied server as soon as possible, saving it into the buffers set by the proxy_buffer_size and proxy_buffers directives. If the whole response does not fit into memory, a part of it can be saved to a temporary file on the disk. https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering"
+  type        = string
+  default     = "off"
+}
 
 variable "memory_limits" {
   description = "value for resources:limits memory value"


### PR DESCRIPTION
```
When proxy buffering is disabled, NGINX buffers only the first part of a server’s response before starting to send it to the client, in a buffer that by default is one memory page in size (4 KB or 8 KB depending on the operating system). This is usually just enough space for the response header. NGINX then sends the response to the client synchronously as it receives it, forcing the server to sit idle as it waits until NGINX can accept the next response segment. 
```

proxy-buffering is off by default

https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/configmap.md#configuration-options

https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/#proxy_buffering-off