### PR TITLE
feat: 🎸 optional enable cross zone lb

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ No modules.
 | <a name="input_cluster_domain_name"></a> [cluster\_domain\_name](#input\_cluster\_domain\_name) | The cluster domain used for externalDNS annotations and certmanager | `any` | n/a | yes |
 | <a name="input_controller_name"></a> [controller\_name](#input\_controller\_name) | Will be used as the ingress controller name and the class annotation | `string` | n/a | yes |
 | <a name="input_default_cert"></a> [default\_cert](#input\_default\_cert) | Useful if you want to use a default certificate for your ingress controller. Format: namespace/secretName | `string` | `"ingress-controllers/default-certificate"` | no |
+| <a name="input_enable_cross_zone_lb"></a> [enable\_cross\_zone\_lb](#input\_enable\_cross\_zone\_lb) | cross-zone load balancing distributes traffic across the registered targets in all enabled Availability Zones | `bool` | `true` | no |
 | <a name="input_enable_external_dns_annotation"></a> [enable\_external\_dns\_annotation](#input\_enable\_external\_dns\_annotation) | Add external dns annotation for service | `bool` | `false` | no |
 | <a name="input_enable_latest_tls"></a> [enable\_latest\_tls](#input\_enable\_latest\_tls) | Provide support to tlsv1.3 along with tlsv1.2 | `bool` | `false` | no |
 | <a name="input_enable_modsec"></a> [enable\_modsec](#input\_enable\_modsec) | Enable https://github.com/SpiderLabs/ModSecurity-nginx | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,9 @@ resource "helm_release" "nginx_ingress" {
     enable_owasp            = var.enable_owasp
     keepalive               = var.keepalive
     # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#upstream-keepalive-time
-    upstream_keepalive_time        = var.upstream_keepalive_time
+    upstream_keepalive_time = var.upstream_keepalive_time
+    # https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#cross-zone-load-balancing
+    enable_cross_zone_lb           = var.enable_cross_zone_lb
     proxy_response_buffering       = var.proxy_response_buffering
     default                        = var.controller_name == "default" ? true : false
     name_override                  = "ingress-${var.controller_name}"

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -254,7 +254,7 @@ controller:
 %{~ endif ~}
 
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-      service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+      service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "${enable_cross_zone_lb}"
     externalTrafficPolicy: "Local"
 
 %{ if default_cert != "" }

--- a/variables.tf
+++ b/variables.tf
@@ -81,7 +81,7 @@ variable "upstream_keepalive_time" {
 }
 
 variable "enable_cross_zone_lb" {
-  description = "Limits the maximum time during which requests can be processed through one keepalive connection. After this time is reached, the connection is closed following the subsequent request processing."
+  description = "cross-zone load balancing distributes traffic across the registered targets in all enabled Availability Zones"
   type        = bool
   default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -80,6 +80,12 @@ variable "upstream_keepalive_time" {
   default     = "1h"
 }
 
+variable "enable_cross_zone_lb" {
+  description = "Limits the maximum time during which requests can be processed through one keepalive connection. After this time is reached, the connection is closed following the subsequent request processing."
+  type        = bool
+  default     = true
+}
+
 variable "proxy_response_buffering" {
   description = "nginx receives a response from the proxied server as soon as possible, saving it into the buffers set by the proxy_buffer_size and proxy_buffers directives. If the whole response does not fit into memory, a part of it can be saved to a temporary file on the disk. https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering"
   type        = string


### PR DESCRIPTION
# Overview

**This optimisation will _only be disabled on the 'production-only' ingress_**

We can disable [cross-zone load balancing ](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#cross-zone-load-balancing) because the nlb is created in each subnet, so traffic will still be able to reach each az. It is also worth mentioning that cross-zone load balancing for nlb is disabled by default.

> When you enable an Availability Zone, you specify one subnet from that Availability Zone. Elastic Load Balancing creates a load balancer node in the Availability Zone and a network interface for the subnet (the description starts with "ELB net" and includes the name of the load balancer). Each load balancer node in the Availability Zone uses this network interface to get an IPv4 address
[here](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#availability-zones)

## Diagram overview

disabled:

![image](https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/assets/29051079/8f22533d-69a6-4bf0-840f-4b890907f4c7)

vs.

enabled:

![image](https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/assets/29051079/b8cd2df2-a10e-477d-84bf-7af4367bf966)

## Why

We want to be able to toggle cross-zone load balancing because it can introduce **connection resets** when a connection is mistakenly identified as [originating from a duplicate source](
https://medium.com/swlh/nlb-connection-resets-109720accfc6#:~:text=The%20workaround%3F%20Just%20disable%20cross%2Dzone%20load%20balancing.%20If%20you%E2%80%99re%20running%20stateless%20compute%20with%20more%20than%20a%20few%20instances%20per%20AZ%2C%20or%20a%20second%20proxy%20tier%20like%20us%2C%20you%20don%E2%80%99t%20need%20it%20anyway).

![image](https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/assets/29051079/976b46ac-e214-4a8e-8cab-5ac2bf35ccf7)

### Disadvantages

The disadvantage of disabling cross-zone load balancing is if a client caches the DNS of the lb it could result in lbs receiving ["disproportionally higher number of inbound requests"](https://aws.amazon.com/about-aws/whats-new/2018/02/network-load-balancer-now-supports-cross-zone-load-balancing/)

## Advantages

Benefits include fewer connection resets, marginally reduced latency (not crossing AZs) and [reduced regional data transfer charges](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-cross-zone.html)

```
$0.010 per GB - regional data transfer - in/out/between EC2 AZs or using elastic IPs or ELB # https://cloudiamo.com/2019/01/24/cross-zone-load-balancing-always-on-right/
```

### Dig

You can see the nlb in each subnet az with dig below:

```
; <<>> DiG 9.10.6 <<>> a9a1fce6427fd49058c4c68e57fd8e75-e2e37f01a215aa62.elb.eu-west-2.amazonaws.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 36420
;; flags: qr rd ra; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;a9a1fce6427fd49058c4c68e57fd8e75-e2e37f01a215aa62.elb.eu-west-2.amazonaws.com. IN A

;; ANSWER SECTION:
a9a1fce6427fd49058c4c68e57fd8e75-e2e37f01a215aa62.elb.eu-west-2.amazonaws.com. 60 IN A 13.42.229.97
a9a1fce6427fd49058c4c68e57fd8e75-e2e37f01a215aa62.elb.eu-west-2.amazonaws.com. 60 IN A 3.10.250.16
a9a1fce6427fd49058c4c68e57fd8e75-e2e37f01a215aa62.elb.eu-west-2.amazonaws.com. 60 IN A 18.135.147.246

;; Query time: 34 msec
;; SERVER: 100.64.9.0#53(100.64.9.0)
;; WHEN: Tue Mar 26 09:40:21 GMT 2024
;; MSG SIZE  rcvd: 154
```
