### PR TITLE
Bump helm 4.10.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ resource "helm_release" "nginx_ingress" {
   namespace  = "ingress-controllers"
   repository = "https://kubernetes.github.io/ingress-nginx"
   timeout    = 600
-  version    = "4.7.3"
+  version    = "4.10.4"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     metrics_namespace       = "ingress-controllers"

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ resource "helm_release" "nginx_ingress" {
   namespace  = "ingress-controllers"
   repository = "https://kubernetes.github.io/ingress-nginx"
   timeout    = 600
-  version    = "4.10.4"
+  version    = "4.10.1"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     metrics_namespace       = "ingress-controllers"

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -1,5 +1,7 @@
 nameOverride: ${name_override}
 controller:
+## enableAnnotationValidations defaults to false in 4.10.4, however bringing into template for future ref
+  enableAnnotationValidations: false
   image:
     chroot: false
     terminationGracePeriod: 600
@@ -12,6 +14,12 @@ controller:
       exec:
         command: ["/bin/sh", "-c", "sleep 30; /usr/local/openresty/nginx/sbin/nginx -c /etc/nginx/nginx.conf -s quit; while pgrep -x nginx; do sleep 1; done"]
 
+  # -- This configuration defines if Ingress Controller should allow users to set
+  # their own *-snippet annotations, otherwise this is forbidden / dropped
+  # when users add those annotations.
+  # Global snippets in ConfigMap are still respected
+  allowSnippetAnnotations: true
+  
 %{ if enable_modsec ~}
   extraVolumes:
   ## Additional volumes to the controller pod.


### PR DESCRIPTION
relates to ministryofjustice/cloud-platform#6366

Release:
https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.10.1

This upgrade brings us into compatibility matrix range for eks 1.30 thru 1.28 as prep for our 1.29 upgrade work.

Also maintains CRS at the existing ruleset version for stability