### PR TITLE
fix: 🐛 bug which allows host header injection vuln

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -190,7 +190,7 @@ controller:
 %{ endif ~}
     server-snippet: |
       if ($scheme != 'https') {
-        return 308 https://$host$request_uri;
+        return 308 https://$server_name$request_uri;
       }
 
     #

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -105,11 +105,12 @@ controller:
     - name: logrotate
       securityContext:
         runAsGroup: 82
-      image: debian:bookworm-slim
+      image: debian:bookworm-20241016-slim
       command:
         - sh
         - -c
         - |
+          export DEBIAN_FRONTEND=noninteractive
           apt update
           apt install logrotate -y
           groupadd -g 82 82


### PR DESCRIPTION
- the [$host ](http://nginx.org/en/docs/http/ngx_http_core_module.html#var_host) var uses the value passed in from the host request header opening up a host header injection vulnerability use the [$server_name](http://nginx.org/en/docs/http/ngx_http_core_module.html#var_server_name) var instead
- silence terminal warnings in logrotate
- pin logrotate

closes https://github.com/orgs/ministryofjustice/projects/65/views/3?pane=issue&itemId=80388737&issue=ministryofjustice%7Ccloud-platform%7C6174