### PR TITLE
feat: 🎸 set default backend as system-cluster-critical

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -328,6 +328,7 @@ defaultBackend:
   image:
     repository: "${backend_repo}"
     tag: "${backend_tag}"
+  priorityClassName: "system-cluster-critical"
 
 rbac:
   create: true


### PR DESCRIPTION
this will ensure that descheduler will not consider ingress controller default backends for eviction

relates to ministryofjustice/cloud-platform#6387