### PR TITLE
chore: 🤖 bump to latest version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ resource "helm_release" "nginx_ingress" {
   namespace  = "ingress-controllers"
   repository = "https://kubernetes.github.io/ingress-nginx"
   timeout    = 600
-  version    = "4.10.1"
+  version    = "4.12.1"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     metrics_namespace       = "ingress-controllers"

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -206,6 +206,7 @@ controller:
     keepalive: ${keepalive}
     proxy-buffering: "${proxy_response_buffering}"
     upstream-keepalive-time: "${upstream_keepalive_time}"
+    annotations-risk-level: "Critical"
 
 %{ if enable_latest_tls }
     ssl-protocols: "TLSv1.2 TLSv1.3"


### PR DESCRIPTION
- bump to the latest nginx helm chart and controller
- allow snippets (used in default and modsec classes)