### PR TITLE
fix: 🐛 clashing configmap names

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ No modules.
 | <a name="input_enable_modsec"></a> [enable\_modsec](#input\_enable\_modsec) | Enable https://github.com/SpiderLabs/ModSecurity-nginx | `bool` | `false` | no |
 | <a name="input_enable_owasp"></a> [enable\_owasp](#input\_enable\_owasp) | Use default ruleset from https://github.com/SpiderLabs/owasp-modsecurity-crs/ | `bool` | `false` | no |
 | <a name="input_fluent_bit_version"></a> [fluent\_bit\_version](#input\_fluent\_bit\_version) | fluent bit container version used to exrtact modsec audit logs | `string` | `"3.0.2-amd64"` | no |
+| <a name="input_is_dev_only_modsec"></a> [is\_dev\_only\_modsec](#input\_is\_dev\_only\_modsec) | is dev only modsec controller | `bool` | `false` | no |
 | <a name="input_is_live_cluster"></a> [is\_live\_cluster](#input\_is\_live\_cluster) | For live clusters externalDNS annotation will have var.live\_domain (default *.cloud-platform.service.justice.gov.uk) | `bool` | `false` | no |
 | <a name="input_keepalive"></a> [keepalive](#input\_keepalive) | the maximum number of idle keepalive connections to upstream servers that are preserved in the cache of each worker process. When this number is exceeded, the least recently used connections are closed. https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive | `number` | `320` | no |
 | <a name="input_live1_cert_dns_name"></a> [live1\_cert\_dns\_name](#input\_live1\_cert\_dns\_name) | This is to add the live-1 dns name for eks-live cluster default certificate | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ No modules.
 | <a name="input_enable_modsec"></a> [enable\_modsec](#input\_enable\_modsec) | Enable https://github.com/SpiderLabs/ModSecurity-nginx | `bool` | `false` | no |
 | <a name="input_enable_owasp"></a> [enable\_owasp](#input\_enable\_owasp) | Use default ruleset from https://github.com/SpiderLabs/owasp-modsecurity-crs/ | `bool` | `false` | no |
 | <a name="input_fluent_bit_version"></a> [fluent\_bit\_version](#input\_fluent\_bit\_version) | fluent bit container version used to exrtact modsec audit logs | `string` | `"3.0.2-amd64"` | no |
-| <a name="input_is_dev_only_modsec"></a> [is\_dev\_only\_modsec](#input\_is\_dev\_only\_modsec) | is dev only modsec controller | `bool` | `false` | no |
+| <a name="input_is_non_prod_modsec"></a> [is\_dev\_only\_modsec](#input\_is\_dev\_only\_modsec) | is dev only modsec controller | `bool` | `false` | no |
 | <a name="input_is_live_cluster"></a> [is\_live\_cluster](#input\_is\_live\_cluster) | For live clusters externalDNS annotation will have var.live\_domain (default *.cloud-platform.service.justice.gov.uk) | `bool` | `false` | no |
 | <a name="input_keepalive"></a> [keepalive](#input\_keepalive) | the maximum number of idle keepalive connections to upstream servers that are preserved in the cache of each worker process. When this number is exceeded, the least recently used connections are closed. https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive | `number` | `320` | no |
 | <a name="input_live1_cert_dns_name"></a> [live1\_cert\_dns\_name](#input\_live1\_cert\_dns\_name) | This is to add the live-1 dns name for eks-live cluster default certificate | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ No modules.
 | <a name="input_enable_modsec"></a> [enable\_modsec](#input\_enable\_modsec) | Enable https://github.com/SpiderLabs/ModSecurity-nginx | `bool` | `false` | no |
 | <a name="input_enable_owasp"></a> [enable\_owasp](#input\_enable\_owasp) | Use default ruleset from https://github.com/SpiderLabs/owasp-modsecurity-crs/ | `bool` | `false` | no |
 | <a name="input_fluent_bit_version"></a> [fluent\_bit\_version](#input\_fluent\_bit\_version) | fluent bit container version used to exrtact modsec audit logs | `string` | `"3.0.2-amd64"` | no |
-| <a name="input_is_non_prod_modsec"></a> [is\_dev\_only\_modsec](#input\_is\_dev\_only\_modsec) | is dev only modsec controller | `bool` | `false` | no |
 | <a name="input_is_live_cluster"></a> [is\_live\_cluster](#input\_is\_live\_cluster) | For live clusters externalDNS annotation will have var.live\_domain (default *.cloud-platform.service.justice.gov.uk) | `bool` | `false` | no |
+| <a name="input_is_non_prod_modsec"></a> [is\_non\_prod\_modsec](#input\_is\_non\_prod\_modsec) | is non-prod modsec controller | `bool` | `false` | no |
 | <a name="input_keepalive"></a> [keepalive](#input\_keepalive) | the maximum number of idle keepalive connections to upstream servers that are preserved in the cache of each worker process. When this number is exceeded, the least recently used connections are closed. https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive | `number` | `320` | no |
 | <a name="input_live1_cert_dns_name"></a> [live1\_cert\_dns\_name](#input\_live1\_cert\_dns\_name) | This is to add the live-1 dns name for eks-live cluster default certificate | `string` | `""` | no |
 | <a name="input_live_domain"></a> [live\_domain](#input\_live\_domain) | The live domain used for externalDNS annotation | `string` | `"cloud-platform.service.justice.gov.uk"` | no |

--- a/configmap.tf
+++ b/configmap.tf
@@ -2,7 +2,7 @@ resource "kubernetes_config_map" "fluent-bit-config" {
   count = var.enable_modsec ? 1 : 0
 
   metadata {
-    name      = var.is_dev_only_modsec ? "fluent-bit-config-${var.controller_name}" : "fluent-bit-config"
+    name      = var.is_non_prod_modsec ? "fluent-bit-config-${var.controller_name}" : "fluent-bit-config"
     namespace = "ingress-controllers"
     labels = {
       "k8s-app" = var.controller_name
@@ -225,7 +225,7 @@ resource "kubernetes_config_map" "fluent_bit_lua_script" {
   count = var.enable_modsec ? 1 : 0
 
   metadata {
-    name      = var.is_dev_only_modsec ? "fluent-bit-luascripts-${var.controller_name}" : "fluent-bit-luascripts"
+    name      = var.is_non_prod_modsec ? "fluent-bit-luascripts-${var.controller_name}" : "fluent-bit-luascripts"
     namespace = "ingress-controllers"
     labels = {
       "k8s-app" = var.controller_name
@@ -287,7 +287,7 @@ resource "kubernetes_config_map" "modsecurity_nginx_config" {
 
   metadata {
 
-    name      = var.is_dev_only_modsec ? "modsecurity-nginx-config-${var.controller_name}" : "modsecurity-nginx-config"
+    name      = var.is_non_prod_modsec ? "modsecurity-nginx-config-${var.controller_name}" : "modsecurity-nginx-config"
     namespace = "ingress-controllers"
     labels = {
       "k8s-app" = var.controller_name
@@ -312,7 +312,7 @@ resource "kubernetes_config_map" "logrotate_config" {
 
   metadata {
 
-    name      = var.is_dev_only_modsec ? "logrotate-config-${var.controller_name}" : "logrotate-config"
+    name      = var.is_non_prod_modsec ? "logrotate-config-${var.controller_name}" : "logrotate-config"
     namespace = "ingress-controllers"
     labels = {
       "k8s-app" = var.controller_name

--- a/configmap.tf
+++ b/configmap.tf
@@ -2,7 +2,7 @@ resource "kubernetes_config_map" "fluent-bit-config" {
   count = var.enable_modsec ? 1 : 0
 
   metadata {
-    name      = "fluent-bit-config"
+    name      = var.is_dev_only_modsec ? "fluent-bit-config-${var.controller_name}" : "fluent-bit-config"
     namespace = "ingress-controllers"
     labels = {
       "k8s-app" = var.controller_name
@@ -225,7 +225,7 @@ resource "kubernetes_config_map" "fluent_bit_lua_script" {
   count = var.enable_modsec ? 1 : 0
 
   metadata {
-    name      = "fluent-bit-luascripts"
+    name      = var.is_dev_only_modsec ? "fluent-bit-luascripts-${var.controller_name}" : "fluent-bit-luascripts"
     namespace = "ingress-controllers"
     labels = {
       "k8s-app" = var.controller_name
@@ -286,7 +286,8 @@ resource "kubernetes_config_map" "modsecurity_nginx_config" {
   count = var.enable_modsec ? 1 : 0
 
   metadata {
-    name      = "modsecurity-nginx-config"
+
+    name      = var.is_dev_only_modsec ? "modsecurity-nginx-config-${var.controller_name}" : "modsecurity-nginx-config"
     namespace = "ingress-controllers"
     labels = {
       "k8s-app" = var.controller_name
@@ -310,7 +311,8 @@ resource "kubernetes_config_map" "logrotate_config" {
   count = var.enable_modsec ? 1 : 0
 
   metadata {
-    name      = "logrotate-config"
+
+    name      = var.is_dev_only_modsec ? "logrotate-config-${var.controller_name}" : "logrotate-config"
     namespace = "ingress-controllers"
     labels = {
       "k8s-app" = var.controller_name

--- a/variables.tf
+++ b/variables.tf
@@ -127,3 +127,9 @@ variable "enable_anti_affinity" {
   type        = bool
   default     = false
 }
+
+variable "is_dev_only_modsec" {
+  description = "is dev only modsec controller"
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -128,8 +128,8 @@ variable "enable_anti_affinity" {
   default     = false
 }
 
-variable "is_dev_only_modsec" {
-  description = "is dev only modsec controller"
+variable "is_non_prod_modsec" {
+  description = "is non-prod modsec controller"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
allow dev only modsec to seperate out configmap names to prevent creation errors