### PR TITLE
fix: 🐛 error log pipeline

### DIFF
--- a/configmap.tf
+++ b/configmap.tf
@@ -74,7 +74,7 @@ resource "kubernetes_config_map" "fluent-bit-config" {
         Match                             ingress-modsec-stdout.*
         Rule                              $log (Modsecurity|ModSecurity|ModSecurity-nginx|modsecurity|OWASP_CRS|owasp-modsecurity-crs) nginx-modsec-error-log.$TAG false
         Emitter_Storage.type              filesystem
-        Emitter_Mem_Buf_Limit             500MB
+        Emitter_Mem_Buf_Limit             1500MB
 
     [FILTER]
         Name                              lua


### PR DESCRIPTION
- bump emitter mem limit