### PR TITLE
chore: 🤖 set helm release to 4.12.0 for 1.12.0 nginx release

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ resource "helm_release" "nginx_ingress" {
   namespace  = "ingress-controllers"
   repository = "https://kubernetes.github.io/ingress-nginx"
   timeout    = 600
-  version    = "4.12.1"
+  version    = "4.12.0"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     metrics_namespace       = "ingress-controllers"


### PR DESCRIPTION
This PR rolls back ingress controller version from `1.12.1` to `1.12.0` in order to re-enable admission webhook point validation of ingress configurations.

We will consider this a temporary solution to prevent ingress controller breakdowns across the cluster due to incorrect user configs, whilst we focus on implementing our own validation controller to replace this lost functionality (assuming that it doesn't get restored in an upcoming nginx ingress release)