### PR TITLE
perf: ⚡️ bump emitter mem limit

### DIFF
--- a/configmap.tf
+++ b/configmap.tf
@@ -74,7 +74,7 @@ resource "kubernetes_config_map" "fluent-bit-config" {
         Match                             ingress-modsec-stdout.*
         Rule                              $log (Modsecurity|ModSecurity|ModSecurity-nginx|modsecurity|OWASP_CRS|owasp-modsecurity-crs) nginx-modsec-error-log.$TAG false
         Emitter_Storage.type              filesystem
-        Emitter_Mem_Buf_Limit             2000MB
+        Emitter_Mem_Buf_Limit             6000MB
 
     [FILTER]
         Name                              lua


### PR DESCRIPTION
- after a while modsec error logs start dropping by around 10%
- It's possible that bumping the memory won't solve the issue but I want to rule it out (the container has a limit of 20gb)