### PR TITLE
chore: 🤖 reduce emitter memory buffer 4 > 3gb

### DIFF
--- a/configmap.tf
+++ b/configmap.tf
@@ -74,7 +74,7 @@ resource "kubernetes_config_map" "fluent-bit-config" {
         Match                             ingress-modsec-stdout.*
         Rule                              $log (Modsecurity|ModSecurity|ModSecurity-nginx|modsecurity|OWASP_CRS|owasp-modsecurity-crs) nginx-modsec-error-log.$TAG false
         Emitter_Storage.type              filesystem
-        Emitter_Mem_Buf_Limit             4000MB
+        Emitter_Mem_Buf_Limit             3000MB
 
     [FILTER]
         Name                              lua


### PR DESCRIPTION
to address failing int tests and assess impact on fluent bit container memory consumption for modsec