### PR TITLE
outputting logs to S3 in debug mode

### DIFF
--- a/configmap.tf
+++ b/configmap.tf
@@ -255,6 +255,7 @@ resource "kubernetes_config_map" "fluent-bit-config" {
         s3_key_format                     /logs/audit/%Y/%m/%d/%H/%M/%S-$UUID
         use_put_object                    true
         Retry_Limit                       False
+
     [OUTPUT]
         Name                              s3
         Alias                             modsec_nginx_ingress_stdout_s3


### PR DESCRIPTION
This PR will start pushing modsec logs concurrently to S3 in debug mode.

The purpose is to capture fluent-bit system logs of modsec logs going to OpenSearch tapering off and eventually failing. Will then revert when I've captured enough logs.

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7324