### PR TITLE
putting S3 output's temp storage in its own directory

### DIFF
--- a/configmap.tf
+++ b/configmap.tf
@@ -250,7 +250,7 @@ resource "kubernetes_config_map" "fluent-bit-config" {
         region                            eu-west-2
         total_file_size                   5M
         upload_timeout                    1m
-        store_dir                         /tmp/fluent-bit/s3
+        store_dir                         /tmp/fluent-bit/s3-audit
         store_dir_limit_size              1G
         s3_key_format                     /logs/audit/%Y/%m/%d/%H/%M/%S-$UUID
         use_put_object                    true
@@ -264,7 +264,7 @@ resource "kubernetes_config_map" "fluent-bit-config" {
         region                            eu-west-2
         total_file_size                   5M
         upload_timeout                    1m
-        store_dir                         /tmp/fluent-bit/s3
+        store_dir                         /tmp/fluent-bit/s3-stdout
         store_dir_limit_size              1G
         s3_key_format                     /logs/stdout/%Y/%m/%d/%H/%M/%S-$UUID
         use_put_object                    true


### PR DESCRIPTION
Tweaking config as part of debug

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7324