### PR TITLE
increasing max_chunks_up

### DIFF
--- a/configmap.tf
+++ b/configmap.tf
@@ -21,7 +21,7 @@ resource "kubernetes_config_map" "fluent-bit-config" {
         HTTP_Listen                       0.0.0.0
         HTTP_Port                         2020
         Storage.path                      /var/log/flb-storage/
-        Storage.max_chunks_up             128
+        Storage.max_chunks_up             256
         Storage.backlog.mem_limit         100MB
 
     [INPUT]


### PR DESCRIPTION
Increasing `Storage.max_chunks_up` from 128 to 256 as we're seeing the following when outputting to S3:
```
nginx-ingress-modsec-controller-58797fd96b-9xvjp flb-modsec-logs [2025/07/30 19:22:28] [ info] [input] modsec_nginx_ingress_audit resume (storage buf overlimit 127/128)
```

Increasing as per [fluent-bit doc](https://docs.fluentbit.io/manual/administration/buffering-and-storage#filesystem-buffering)

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7324