### PR TITLE
reduce log_level verbosity

### DIFF
--- a/configmap.tf
+++ b/configmap.tf
@@ -12,7 +12,7 @@ resource "kubernetes_config_map" "fluent-bit-config" {
     "fluent-bit.conf" = <<-EOT
     [SERVICE]
         Flush                             1
-        Log_Level                         debug
+        Log_Level                         info
         Daemon                            Off
         Grace                             30
         Parsers_File                      parsers.conf


### PR DESCRIPTION
There may be too many logs being queued in the storage buffer. Reducing the log level to alleviate this.

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7324 