### PR TITLE
Debug: Remove modsec audit S3 output

### DIFF
--- a/configmap.tf
+++ b/configmap.tf
@@ -244,20 +244,6 @@ resource "kubernetes_config_map" "fluent-bit-config" {
 
     [OUTPUT]
         Name                              s3
-        Alias                             modsec_nginx_ingress_audit_s3
-        Match                             cp-ingress-modsec-audit.*
-        bucket                            ${module.s3_bucket_modsec_logs[0].bucket_name}
-        region                            eu-west-2
-        total_file_size                   5M
-        upload_timeout                    1m
-        store_dir                         /tmp/fluent-bit/s3-audit
-        store_dir_limit_size              3G
-        s3_key_format                     /logs/audit/%Y/%m/%d/%H/%M/%S-$UUID
-        use_put_object                    true
-        Retry_Limit                       False
-
-    [OUTPUT]
-        Name                              s3
         Alias                             modsec_nginx_ingress_stdout_s3
         Match                             ingress-modsec-stdout.*
         bucket                            ${module.s3_bucket_modsec_logs[0].bucket_name}


### PR DESCRIPTION
Homing in on modsec `stdout` logs going to S3 as the culprit causing the `storage buf overlimit`

Removing modsec `audit` logs going to S3 to ascertain that this output is not a factor in `storage buf overlimit`