### PR TITLE
feat: migrate to chainguard-credentials secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,13 @@ See [example](example/) dir
 | [kubernetes_config_map.logrotate_config](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_config_map.modsecurity_nginx_config](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_namespace.ingress_controllers](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [kubernetes_secret.chainguard_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.s3_bucket_modsec_logs](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.eks_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_iam_policy_document.modsec_fluentbit_irsa_trust_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_ssm_parameter.chainguard_registry_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 
 ## Inputs
 

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -1,6 +1,6 @@
 %{ if enable_chainguard ~}
 imagePullSecrets:
-  - name: chainguard-creds
+  - name: chainguard-credentials
 %{ endif ~}
 
 nameOverride: ${name_override}


### PR DESCRIPTION
## Purpose

- Changes the helm chart secret from `chaingaurd-creds` to `chainguard-credentials` provided by the 3.2.0 release of this module
- This will rollout restart all ingress controllers
- Expect to see helm release updating in terraform